### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: latest
+          extended: true
+
+      - name: Build site
+        run: hugo --minify
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ hugo server -D
 
 The site will be available at `http://localhost:1313/`.
 
+
+## Deployment
+
+Commits to the `main` branch are automatically built and published to GitHub Pages via GitHub Actions.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds the Hugo site and deploys to GitHub Pages
- document automatic GitHub Pages deployment in README

## Testing
- `hugo` *(fails: error building site; template for shortcode "gallery" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1066cdbc083248710fa69b1f62fdd